### PR TITLE
add some defaults

### DIFF
--- a/templates/index.nix
+++ b/templates/index.nix
@@ -4,10 +4,10 @@ with lib;
 let content =
   ''
   <div class="posts">
-    ${mapTemplate templates.post.list page.items}
+    ${mapTemplate templates.post.list (page.items or [])}
   </div>
 
-  ${templates.partials.pagination { pages = page.pages; index = page.index; }} 
+  ${templates.partials.pagination { pages = (page.pages or []); index = page.index; }} 
   '';
 in
  page // { inherit content; }

--- a/templates/partials/sidebar.nix
+++ b/templates/partials/sidebar.nix
@@ -16,7 +16,7 @@ with lib;
       <li><a href="/">Home</a></li>
       ${mapTemplate (menu: ''
         <li><a href="${conf.siteUrl}/${menu.href}">${menu.title}</a></li>
-      '') data.menus}
+      '') (data.menus or [])}
     </ul>
 
     <p>&copy; 2016. All rights reserved.</p>


### PR DESCRIPTION
add some defaults so we don't have to specify all theme attributes in site.nix

For example, this is the minimal page `site.nix`, as I expected

```
  pages = rec {

    index = {
      title = "Home";
      href = "index.html";
      template = templates.index;
      layout = templates.layout;
    };

  };
```
